### PR TITLE
Add optional Vampir auto-launch integration

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,3 +4,15 @@ __pycache__/
 build
 logs_scorep_jupyter/
 **/*.egg-info
+
+# PyCharm
+.idea/
+.ipynb_checkpoints/
+
+# Jupyter Notebook
+.ipynb_checkpoints
+
+# Ignore all result directories inside examples/ at any depth
+examples/**/scorep-*/
+
+

--- a/README.md
+++ b/README.md
@@ -29,13 +29,14 @@ For binding to Score-P, the kernel uses the [Score-P Python bindings](https://gi
 - [Usage](#usage)
   - [Score-P Instrumentation](#score-p-instrumentation)
     - [Configuring Score-P in Jupyter](#configuring-score-p-in-jupyter)
+    - [Vampir Launch Control](#vampir-launch-control)
   - [Multi-Cell Mode](#multi-cell-mode)
   - [Write Mode](#write-mode)
+  - [Logging Configuration](#logging-configuration)
 - [Presentation of Performance Data](#presentation-of-performance-data)
 - [Limitations](#limitations)
   - [Serialization Type Support](#serialization-type-support)
   - [Overhead](#overhead)
-  - [Logging Configuration](#logging-configuration)
 - [Future Work](#future-work)
 - [Citing](#citing)
 - [Contact](#contact)
@@ -131,7 +132,22 @@ Executes a cell with Score-P, i.e. it calls `python -m scorep <cell code>`
 
 ![](doc/instrumentation.gif)
 
+### Vampir Launch Control
 
+To automatically launch **Vampir** after a cell with Score-P instrumentation, use:
+
+```
+%%enable_vampir_launch_on_scorep_instrumented
+```
+
+This will cause the kernel to open `traces.otf2` in Vampir (if found) after the next instrumented cell.  
+To disable this behavior again:
+
+```
+%%disable_vampir_launch
+```
+
+By default, Vampir launching is disabled. You must enable it explicitly when needed.
 
 ## Multi-Cell Mode
 You can also treat multiple cells as one single cell by using the multi cell mode. Therefore you can mark the cells in the order you wish to execute them.
@@ -186,6 +202,23 @@ Stops the marking process and writes the marked cells in a Python script. Additi
 
 ![](doc/writemode.gif)
 
+## Logging Configuration
+To adjust logging and obtain more detailed output about the behavior of the scorep_jupyter kernel, refer to the `src/logging_config.py` file.
+This file contains configuration options for controlling the verbosity, format, and destination of log messages. You can customize it to suit your debugging needs.
+
+Log files are stored in the following directory:
+```
+scorep_jupyter_kernel_python/
+├── logs_scorep_jupyter/
+│   ├── debug.log
+│   ├── info.log
+└── └── error.log
+```
+In some cases, you may want to suppress tqdm messages that are saved to error.log (since tqdm outputs to stderr). This can be done using the following environment variable:
+```
+%env TQDM_DISABLE=1
+```
+
 
 # Presentation of Performance Data
 
@@ -204,23 +237,6 @@ Similar yields for cloudpickle. Use the `%%marshalling_settings` magic command t
 ## Overhead
 
 When dealing with big data structures, there might be a big runtime overhead at the beginning and the end of a Score-P cell. This is due to additional data saving and loading processes for persistency in the background. However this does not affect the actual user code and the Score-P measurements.
-
-## Logging Configuration
-To adjust logging and obtain more detailed output about the behavior of the scorep_jupyter kernel, refer to the `src/logging_config.py` file.
-This file contains configuration options for controlling the verbosity, format, and destination of log messages. You can customize it to suit your debugging needs.
-
-Log files are stored in the following directory:
-```
-scorep_jupyter_kernel_python/
-├── logs_scorep_jupyter/
-│   ├── debug.log
-│   ├── info.log
-└── └── error.log
-```
-In some cases, you may want to suppress tqdm messages that are saved to error.log (since tqdm outputs to stderr). This can be done using the following environment variable:
-```
-%env TQDM_DISABLE=1
-```
 
 # Future Work
 

--- a/src/scorep_jupyter/kernel.py
+++ b/src/scorep_jupyter/kernel.py
@@ -900,7 +900,10 @@ class scorep_jupyterKernel(IPythonKernel):
 
         elif code.startswith("%%enable_vampir_launch_on_scorep_instrumented"):
             self.launch_vampir_requested = True
-            self.cell_output("Vampir will be launched after next instrumented execution.")
+            if shutil.which("vampir") is None:
+                self.log_error(KernelErrorCode.VAMPIR_NOT_FOUND)
+            else:
+                self.cell_output("Vampir will be launched after next instrumented execution.")
             return self.standard_reply()
         elif code.startswith("%%disable_vampir_launch"):
             self.launch_vampir_requested = False

--- a/src/scorep_jupyter/kernel.py
+++ b/src/scorep_jupyter/kernel.py
@@ -898,9 +898,13 @@ class scorep_jupyterKernel(IPythonKernel):
         elif code.startswith("%%end_writefile"):
             return self.scorep_not_available() or self.end_writefile()
 
-        elif code.startswith("%%launch_vampir_on_scorep_instrumented"):
+        elif code.startswith("%%enable_vampir_launch_on_scorep_instrumented"):
             self.launch_vampir_requested = True
             self.cell_output("Vampir will be launched after next instrumented execution.")
+            return self.standard_reply()
+        elif code.startswith("%%disable_vampir_launch"):
+            self.launch_vampir_requested = False
+            self.cell_output("Vampir launching disabled.")
             return self.standard_reply()
         elif code.startswith("%%execute_with_scorep"):
             scorep_missing = self.scorep_not_available()

--- a/src/scorep_jupyter/kernel_messages.py
+++ b/src/scorep_jupyter/kernel_messages.py
@@ -12,6 +12,8 @@ class KernelErrorCode(Enum):
     SCOREP_SUBPROCESS_FAIL = auto()
     SCOREP_NOT_AVAILABLE = auto()
     SCOREP_PYTHON_NOT_AVAILABLE = auto()
+    VAMPIR_NOT_FOUND = auto()
+    VAMPIR_LAUNCH_FAILED = auto()
 
 
 KERNEL_ERROR_MESSAGES = {
@@ -37,6 +39,17 @@ KERNEL_ERROR_MESSAGES = {
     KernelErrorCode.SCOREP_SUBPROCESS_FAIL: (
         "[mode: {mode}] Subprocess terminated unexpectedly. "
         "Persistence not recorded (marshaller: {marshaller})."
+    ),
+    KernelErrorCode.INSTRUMENTATION_PATH_UNKNOWN: (
+        "Instrumentation output directory not found or missing traces.otf2 "
+        "(looked in: {scorep_folder})"
+    ),
+    KernelErrorCode.VAMPIR_NOT_FOUND: (
+        "Vampir binary not found in PATH. Cannot launch visualization."
+    ),
+
+    KernelErrorCode.VAMPIR_LAUNCH_FAILED: (
+        "Failed to launch Vampir: {exception}"
     ),
 }
 

--- a/src/scorep_jupyter/kernel_messages.py
+++ b/src/scorep_jupyter/kernel_messages.py
@@ -45,8 +45,8 @@ KERNEL_ERROR_MESSAGES = {
         "(looked in: {scorep_folder})"
     ),
     KernelErrorCode.VAMPIR_NOT_FOUND: (
-        "Vampir binary not found in PATH. Add it to PATH to enable automatic launch"
-        " (e.g. via `%env PATH=/path/to/vampir/bin:$PATH`)."
+        'Vampir binary not found in PATH. Add it to PATH to enable automatic launch'
+        ' (e.g. in ~/.bashrc: export PATH="/path/to/vampir/bin:$PATH"' 
     ),
 
     KernelErrorCode.VAMPIR_LAUNCH_FAILED: (

--- a/src/scorep_jupyter/kernel_messages.py
+++ b/src/scorep_jupyter/kernel_messages.py
@@ -45,7 +45,8 @@ KERNEL_ERROR_MESSAGES = {
         "(looked in: {scorep_folder})"
     ),
     KernelErrorCode.VAMPIR_NOT_FOUND: (
-        "Vampir binary not found in PATH. Cannot launch visualization."
+        "Vampir binary not found in PATH. Add it to PATH to enable automatic launch"
+        " (e.g. via `%env PATH=/path/to/vampir/bin:$PATH`)."
     ),
 
     KernelErrorCode.VAMPIR_LAUNCH_FAILED: (

--- a/src/scorep_jupyter/kernel_messages.py
+++ b/src/scorep_jupyter/kernel_messages.py
@@ -1,4 +1,3 @@
-import os
 from enum import Enum, auto
 
 from .logging_config import LOGGING

--- a/src/scorep_jupyter/logging_config.py
+++ b/src/scorep_jupyter/logging_config.py
@@ -5,8 +5,6 @@ from pathlib import Path
 
 
 PROJECT_ROOT = Path(__file__).resolve().parent.parent.parent
-print(f"{Path(__file__).as_uri()=}")
-print(f"{PROJECT_ROOT=}")
 LOGGING_DIR = PROJECT_ROOT / "logs_scorep_jupyter"
 os.makedirs(LOGGING_DIR, exist_ok=True)
 

--- a/tests/test_kernel.py
+++ b/tests/test_kernel.py
@@ -186,6 +186,8 @@ class KernelTestLogError(unittest.TestCase):
             "detail": "dummy_detail",
             "step": "dummy_step",
             "optional_hint": "dummy_optional_hint",
+            "scorep_folder": "/fake/path/to/scorep-dir",
+            "exception": "dummy_exception",
         }
 
         for code, template in KERNEL_ERROR_MESSAGES.items():


### PR DESCRIPTION
Adds optional Vampir launching functionality. When enabled by a magic command, the kernel will automatically launch Vampir on the generated traces.otf2 file after Score-P instrumented cell execution.

### Features
`%%enable_vampir_launch_on_scorep_instrumented` magic:

Enables Vampir auto-launch after the next Score-P instrumented execution.

`%%disable_vampir_launch` magic:

Disables Vampir auto-launch.